### PR TITLE
Add a requirements.txt file.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Pillow==8.4.0
+astropy==4.3.1
+matplotlib==2.2.5
+numpy==1.21.4


### PR DESCRIPTION
* pins versions of primary dependencies
* pins matplotlib at 2.2.5, which is the last version supported by
  python 2, and a version of the library that the code seems to be
  compatible with